### PR TITLE
Detect positive RSSI

### DIFF
--- a/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal.lua
+++ b/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal.lua
@@ -121,6 +121,9 @@ end
 
 function STA:update(info)
    self.signal = info.signal
+   if self.signal > 0 then
+      self.signal = -120
+   end
    self.noise = info.noise
    self.snr = self.signal - self.noise
 end

--- a/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal.lua
+++ b/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal.lua
@@ -121,6 +121,9 @@ end
 
 function STA:update(info)
    self.signal = info.signal
+   if self.signal > 0 then
+      self.signal = -128 - (127 - self.signal)
+   end
    self.noise = info.noise
    self.snr = self.signal - self.noise
 end

--- a/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal.lua
+++ b/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal.lua
@@ -122,7 +122,7 @@ end
 function STA:update(info)
    self.signal = info.signal
    if self.signal > 0 then
-      self.signal = -120
+      self.signal = -128 - (127 - self.signal)
    end
    self.noise = info.noise
    self.snr = self.signal - self.noise


### PR DESCRIPTION
Not sure if this a WIFI driver bug but two device with difference WIFI chipset (Xiaomi redmi AC2100 and TP-Link WPA8630 V2) running snapshot report positive RSSI when signal strength is lower than -80db. This detect positive RSSI then replace it with very low signal strength value.