### PR TITLE
Fix Follow Redirect Logic

### DIFF
--- a/curl-websocket/curl-websocket.c
+++ b/curl-websocket/curl-websocket.c
@@ -798,7 +798,7 @@ static size_t _cws_receive_data(const char *buffer, size_t count, size_t nitems,
         buffer += used;
     }
 
-    return len;
+    return count * nitems;
 }
 
 static size_t _cws_send_data(char *buffer, size_t count, size_t nitems, void *data) {


### PR DESCRIPTION
This is a bit fragile since the CURLOPT_FOLLOWLOCATION is outside the
code that handles the redirection logic, but wanted to make this code
leverage curl for handling the redirection logic in this example.

Signed-off-by: Weston Schmidt <Weston_Schmidt@alumni.purdue.edu>