### PR TITLE
Support `wifi-disconnect-low-signal` CLI options in `/etc/config/wireless`

### DIFF
--- a/openwrt/wifi-disconnect-low-signal/README.md
+++ b/openwrt/wifi-disconnect-low-signal/README.md
@@ -241,6 +241,20 @@ openwrt$ opkg install lua libiwinfo-lua libubus-lua luci-lib-nixio libuci-lua
 
 openwrt$ chmod +x /usr/bin/wifi-disconnect-low-signal.lua
 openwrt$ chmod +x /etc/init.d/wifi-disconnect-low-signal
+```
+
+Optionally, add a `wifi-disconnect-low-signal` section to
+`/etc/config/wireless`, and set values for `verbosity` and/or `stderr`:
+
+```
+config wifi-disconnect-low-signal
+	option verbosity '2'  # `-v -v`
+	option stderr 'yes'   # `--stderr`
+```
+
+Then, enable and start the daemon:
+
+```shell-session
 openwrt$ /etc/init.d/wifi-disconnect-low-signal enable
 openwrt$ /etc/init.d/wifi-disconnect-low-signal start
 ```

--- a/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal
+++ b/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal
@@ -54,7 +54,6 @@ start_wifi_disconnect_low_signal() {
 		procd_append_param command --stderr
 	fi
 
-        procd_set_param file "/etc/config/${PACKAGE}"
 	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 	procd_close_instance
 }
@@ -72,5 +71,6 @@ reload_service() {
 }
 
 service_triggers() {
+	procd_add_reload_trigger "$PACKAGE"
 	procd_add_validation validate_wifi_disconnect_low_signal_section
 }

--- a/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal
+++ b/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal
@@ -3,18 +3,74 @@
 START=99
 
 USE_PROCD=1
-NAME=wifi-disconnect-low-signal.lua
-PROG=/usr/bin/wifi-disconnect-low-signal.lua
+PACKAGE=wireless
+TYPE=wifi-disconnect-low-signal
+NAME="${TYPE}.lua"
+PROG="/usr/bin/${TYPE}.lua"
 
-start_service() {
+VERBOSITY=""
+VERBOSITY_DEFAULT=0
+STDERR=""
+STDERR_DEFAULT=0
+
+validate_wifi_disconnect_low_signal_section() {
+	uci_load_validate "$PACKAGE" "$TYPE" "$1" "$2" \
+		"verbosity:range(0,3)" \
+		"stderr:bool"
+}
+
+# This function runs for each `config wifi-disconnect-low-signal` section that
+# appears in `/etc/config/wireless`.  Settings from later sections take
+# precedence over settings from earlier sections.
+configure_wifi_disconnect_low_signal() {
+	if [ "${2:-1}" != 0 ]; then
+		echo "validation failed"
+		return "${2:-1}"
+	fi
+
+	if [ -n "$verbosity" ]; then
+		VERBOSITY="$verbosity"
+	fi
+
+	if [ -n "$stderr" ]; then
+		STDERR="$stderr"
+	fi
+}
+
+start_wifi_disconnect_low_signal() {
+	VERBOSITY="${VERBOSITY:-${VERBOSITY_DEFAULT}}"
+	STDERR="${STDERR:-${STDERR_DEFAULT}}"
+
 	procd_open_instance
 	procd_set_param command "$PROG"
-        procd_set_param file /etc/config/wireless
-	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+
+	verbosity_counter=0
+	while [ "$verbosity_counter" -lt "$VERBOSITY" ]; do
+		procd_append_param command -v
+		verbosity_counter="$(( verbosity_counter + 1 ))"
+	done
+
+	if [ "$STDERR" != 0 ]; then
+		procd_append_param command --stderr
+	fi
+
+        procd_set_param file "/etc/config/${PACKAGE}"
+	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 	procd_close_instance
 }
 
+start_service() {
+	config_load "$PACKAGE"
+	config_foreach validate_wifi_disconnect_low_signal_section "$TYPE" \
+		configure_wifi_disconnect_low_signal
+	start_wifi_disconnect_low_signal
+}
+
 reload_service() {
-    stop
-    start
+	stop
+	start
+}
+
+service_triggers() {
+	procd_add_validation validate_wifi_disconnect_low_signal_section
 }


### PR DESCRIPTION
First, thanks for this handy tool -- it's helped make the wifi roaming experience at home much smoother.

I am working on debugging an issue with certain APs frequently disconnecting clients; the client devices report strong signals, while `wifi-disconnect-low-signal` seems to think that the signals are very weak.  I run the script as an OpenWRT service, as documented in the `README.md`, and it would be handy if I could specify the desired verbosity as a UCI option.  That's what this PR implements: 

```
# /etc/config/wireless
config wifi-disconnect-low-signal
        option verbosity '2' # `-v -v`
```

The PR also introduces support for `--stderr` as a UCI option (though I'm not sure whether this is useful or even makes sense, given that the script runs under `procd` and won't send `stderr` to the console):

```
config wifi-disconnect-low-signal
        option stderr 'yes' # `--stderr`
```

Incidental change: because this changeset adds a `service_triggers` function to the `wifi-disconnect-low-signal` initscript (for the purpose of triggering UCI options validation via `procd_add_validation`), I went ahead and replaced 

```
start_service() {
    # <snip>
    procd_set_param /etc/config/wireless
    # <snip>
}
```

with (effectively)

```
service_triggers() {
    procd_add_reload_trigger
}
```

This should improve reload functionality as explained in [the commit](https://github.com/barbieri/barbieri-playground/commit/6e48e9e5f33e79035193094dc69074aec4c2e052).

Thanks in advance for your consideration!