### PR TITLE
wifi-disconnect-low-signal: optionally treat signal/RSSI values as signifying SNR

### DIFF
--- a/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal
+++ b/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal
@@ -12,11 +12,14 @@ VERBOSITY=""
 VERBOSITY_DEFAULT=0
 STDERR=""
 STDERR_DEFAULT=0
+SIGNAL_CONVERT=""
+SIGNAL_CONVERT_DEFAULT=overflow
 
 validate_wifi_disconnect_low_signal_section() {
 	uci_load_validate "$PACKAGE" "$TYPE" "$1" "$2" \
 		"verbosity:range(0,3)" \
-		"stderr:bool"
+		"stderr:bool" \
+		"signal_convert:or(\"overflow\",\"snr\")"
 }
 
 # This function runs for each `config wifi-disconnect-low-signal` section that
@@ -35,11 +38,16 @@ configure_wifi_disconnect_low_signal() {
 	if [ -n "$stderr" ]; then
 		STDERR="$stderr"
 	fi
+
+	if [ -n "$signal_convert" ]; then
+		SIGNAL_CONVERT="$signal_convert"
+	fi
 }
 
 start_wifi_disconnect_low_signal() {
 	VERBOSITY="${VERBOSITY:-${VERBOSITY_DEFAULT}}"
 	STDERR="${STDERR:-${STDERR_DEFAULT}}"
+	SIGNAL_CONVERT="${SIGNAL_CONVERT:-${SIGNAL_CONVERT_DEFAULT}}"
 
 	procd_open_instance
 	procd_set_param command "$PROG"
@@ -53,6 +61,15 @@ start_wifi_disconnect_low_signal() {
 	if [ "$STDERR" != 0 ]; then
 		procd_append_param command --stderr
 	fi
+
+	case "$SIGNAL_CONVERT" in
+		overflow)
+			procd_append_param command --positive-signal-is-overflow
+			;;
+		snr)
+			procd_append_param command --signal-is-snr
+			;;
+	esac
 
 	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 	procd_close_instance


### PR DESCRIPTION
Related to #7 . 

I have two access points (both TP-Link Archer A7s) that report positive RSSI values for stations connected on 5GHz.  In contrast to the behavior reported in #7, it appears that the signal strength is actually quite good, at least as reported by the clients themselves.  As far as I can tell, the wifi driver/device ~~simply forgot to prepend `-` to the reported RSSI values~~ is reporting the SNR as the signal.

This PR implements a CLI flag, `--signal-is-snr`, that causes `wifi-disconnect-low-signal` to calculate RSSI by adding the reported noise to the reported RSSI, rather than using the default overflow conversion logic.  It also adds the flag `--positive-signal-is-overflow`, which permits forcing the default behavior even if the `--signal-is-snr` flag appears somewhere earlier in the CLI argument vector.  Finally, the PR adds a corresponding UCI option, `signal_convert`, which accepts either `'overflow'` or `'snr'`, for controlling which conversion type is in effect for the `wifi-disconnect-low-signal` OpenWRT service.  This depends on the changes from #21, so I've marked this PR as a draft.

Thanks again for your consideration! 