### PR TITLE
fix: use device-specific signal conversion method

### DIFF
--- a/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal.lua
+++ b/openwrt/wifi-disconnect-low-signal/wifi-disconnect-low-signal.lua
@@ -288,7 +288,7 @@ function Device:get_sta(addr)
    local sta = self.stas[addr]
 
    if sta == nil then
-      sta = STA.new(addr, convert_signal)
+      sta = STA.new(addr, self.convert_signal)
 
       if self.whitelist ~= nil and not sta:matches(self.whitelist) then
          dbg("%s: ignored %s (whitelist)", self.ifname, addr)


### PR DESCRIPTION
if specified, rather than always using the global/default conversion method.  This fixes an issue with the signal conversion selection logic introduced in #22. 

